### PR TITLE
fix: potential name should not consider `#`

### DIFF
--- a/.changeset/modern-cats-count.md
+++ b/.changeset/modern-cats-count.md
@@ -1,0 +1,5 @@
+---
+"markuplint-angular-parser": patch
+---
+
+fix: potential name should not consider #

--- a/packages/angular-parser/src/index.ts
+++ b/packages/angular-parser/src/index.ts
@@ -237,19 +237,21 @@ const visitor = {
        * what means `[]` wrapper is required
        */
       .replace(/^\[attr\./, '')
-      // remove leading `#*` or `[]` and `()` wrapper
-      .replace(/[#()*[\]]/g, '')
+      // remove leading `*`, `[]` and `()` wrapper
+      .replace(/[()*[\]]/g, '')
+    // remove leading `#`
+    const plainName = potentialName.replace(/#/g, '')
     const potentialValue = _value.replace(/(^{\s*{)|(}\s*}$)/g, '')
 
     node.potentialName = potentialName
     node.isInvalid =
       ![
-        potentialName,
-        `#${potentialName}`,
-        `*${potentialName}`,
-        `[${potentialName}]`,
-        `(${potentialName})`,
-        `[(${potentialName})]`,
+        plainName,
+        `#${plainName}`,
+        `*${plainName}`,
+        `[${plainName}]`,
+        `(${plainName})`,
+        `[(${plainName})]`,
       ].includes(name) ||
       ![potentialValue, `{{${potentialValue}}}`].includes(_value) ||
       (dynamicName && dynamicValue)

--- a/packages/angular-parser/test/fixtures/attr-duplication.html
+++ b/packages/angular-parser/test/fixtures/attr-duplication.html
@@ -1,1 +1,2 @@
 <input type="text" [type]="'password'" [attr.type]="text" />
+<input type="text" #type />


### PR DESCRIPTION
```html
<input name="text" #name="ngModel" />
```