### PR TITLE
fix: avoid throwing the error when the attribute is invalid

### DIFF
--- a/.changeset/popular-buckets-fetch.md
+++ b/.changeset/popular-buckets-fetch.md
@@ -1,0 +1,5 @@
+---
+"markuplint-angular-parser": patch
+---
+
+fix: avoid throwing the error when the attribute is invalid

--- a/packages/angular-parser/src/index.ts
+++ b/packages/angular-parser/src/index.ts
@@ -243,27 +243,8 @@ const visitor = {
       .replace(/^\[attr\./, '')
       // remove leading `*`, `[]` and `()` wrapper
       .replace(/[()*[\]]/g, '')
-    // remove leading `#`
-    const plainName = potentialName.replace(/#/g, '')
-    const potentialValue = _value.replace(/(^{\s*{)|(}\s*}$)/g, '')
 
     node.potentialName = potentialName
-
-    const isInvalid =
-      ![
-        plainName,
-        `#${plainName}`,
-        `*${plainName}`,
-        `[${plainName}]`,
-        `(${plainName})`,
-        `[(${plainName})]`,
-      ].includes(name) ||
-      ![potentialValue, `{{${potentialValue}}}`].includes(_value) ||
-      (dynamicName && dynamicValue)
-
-    if (isInvalid) {
-      throw new Error('Parse error: It has invalid attribute')
-    }
 
     nodeList.push(node)
   },


### PR DESCRIPTION
I decide to avoid the parser executing whether an attribute is invalid.

I think it should do that in the rule plugin.
So I will create the rule that whether attributes and directives are invalid.
I do it through another PR.